### PR TITLE
fix(renderPokemon) corrige variável

### DIFF
--- a/js/script.JS
+++ b/js/script.JS
@@ -31,7 +31,7 @@ const renderPokemon = async (pokemon) => {
         pokemonName.innerHTML = data.name;
         pokemonNumber.innerHTML = data.id;
         pokemonImage.src = data['sprites']['versions']['generation-v']['black-white']
-        ['animated']['front-default'];
+        ['animated']['front_default'];
     
         input.value = '';
         searchPokemon = data.id;


### PR DESCRIPTION
O código utilizava `front-default` que está incorreto, a API oferece a imagem com a chave `front_default` usando `_` em vez de `-`.